### PR TITLE
Add allowed_mentions type

### DIFF
--- a/types.go
+++ b/types.go
@@ -1,10 +1,11 @@
 package discordwebhook
 
 type Message struct {
-	Username  *string  `json:"username,omitempty"`
-	AvatarUrl *string  `json:"avatar_url,omitempty"`
-	Content   *string  `json:"content,omitempty"`
-	Embeds    *[]Embed `json:"embeds,omitempty"`
+	Username        *string          `json:"username,omitempty"`
+	AvatarUrl       *string          `json:"avatar_url,omitempty"`
+	Content         *string          `json:"content,omitempty"`
+	Embeds          *[]Embed         `json:"embeds,omitempty"`
+	AllowedMentions *AllowedMentions `json:"allowed_mentions,omitempty`
 }
 
 type Embed struct {
@@ -42,4 +43,10 @@ type Image struct {
 type Footer struct {
 	Text    *string `json:"text,omitempty"`
 	IconUrl *string `json:"icon_url,omitempty"`
+}
+
+type AllowedMentions struct {
+	Parse *[]string `json:"parse,omitempty"`
+	Users *[]string `json:"users,omitempty"`
+	Roles *[]string `json:"roles,omitempty"`
 }


### PR DESCRIPTION
Following on from the documentation, this can make usertagging useless

https://birdie0.github.io/discord-webhooks-guide/structure/allowed_mentions.html

which can be useful when wanting everyone to eventually acknowledge a message however not sending them an actual ping.