### PR TITLE
Update types.go

### DIFF
--- a/types.go
+++ b/types.go
@@ -5,7 +5,7 @@ type Message struct {
 	AvatarUrl       *string          `json:"avatar_url,omitempty"`
 	Content         *string          `json:"content,omitempty"`
 	Embeds          *[]Embed         `json:"embeds,omitempty"`
-	AllowedMentions *AllowedMentions `json:"allowed_mentions,omitempty`
+	AllowedMentions *AllowedMentions `json:"allowed_mentions,omitempty"`
 }
 
 type Embed struct {


### PR DESCRIPTION
Fixed: struct field tag `json:"allowed_mentions,omitempty` not compatible with reflect.StructTag.Get: bad syntax for struct tag value, Missing " at the end of field.