### PR TITLE
feat: add timestamp

### DIFF
--- a/types.go
+++ b/types.go
@@ -1,5 +1,7 @@
 package discordwebhook
 
+import "time"
+
 type Message struct {
 	Username        *string          `json:"username,omitempty"`
 	AvatarUrl       *string          `json:"avatar_url,omitempty"`
@@ -18,6 +20,7 @@ type Embed struct {
 	Thumbnail   *Thumbnail `json:"thumbnail,omitempty"`
 	Image       *Image     `json:"image,omitempty"`
 	Footer      *Footer    `json:"footer,omitempty"`
+	Timestamp   *time.Time `json:"timestamp,omitempty"`
 }
 
 type Author struct {


### PR DESCRIPTION
add timestamp on Embeds

<img width="579" alt="Tangkapan Skrin 2023-05-30 pada 19 58 54" src="https://github.com/gtuk/discordwebhook/assets/11512375/e92c55d0-dc2a-4c4c-97ec-ffc98288250a">

reference: https://birdie0.github.io/discord-webhooks-guide/structure/embed/timestamp.html
